### PR TITLE
Bgoodmon pdf

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -29,12 +29,7 @@ Tufts::Application.configure do
   # Tell Action Mailer not to deliver emails to the real world.
   # The :test delivery method accumulates sent emails in the
   # ActionMailer::Base.deliveries array.
-#  config.action_mailer.delivery_method = :test
-
-  config.action_mailer.smtp_settings = {
-    :address => "smtp.tufts.edu",
-    :port => 25
-  }
+  config.action_mailer.delivery_method = :test
 
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr

--- a/spec/job/create_derivatives_spec.rb
+++ b/spec/job/create_derivatives_spec.rb
@@ -13,85 +13,69 @@ describe Job::CreateDerivatives do
     end
   end
 
-
   describe '#perform' do
-    it 'raises an error if it fails to find the object' do
-      obj_id = 'tufts:1'
-      TuftsPdf.find(obj_id).destroy if TuftsPdf.exists?(obj_id)
+    subject { FactoryGirl.create(:tufts_pdf) }
 
-      job = Job::CreateDerivatives.new('uuid', 'record_id' => obj_id)
+    before(:all) do
+      TuftsPdf.find('tufts:1').destroy if TuftsPdf.exists?('tufts:1')
+    end
+
+    before(:each) do
+      subject.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MISS/archival_pdf/MISS.ISS.IPPI.archival.pdf"  # a PDF with 3 pages
+      subject.datastreams["Archival.pdf"].mimeType = "application/pdf"
+      subject.save
+    end
+
+    it 'raises an error if it fails to find the object' do
+      job = Job::CreateDerivatives.new('uuid', 'record_id' => 'tufts_1')
       expect{job.perform}.to raise_error(ActiveFedora::ObjectNotFoundError)
     end
 
     it 'raises an error if it the archival PDF doesn''t exist' do
-      object = TuftsPdf.new(title: 'test create derivative', displays: ['dl'])
-      object.inner_object.pid = 'tufts:MISS.ISS.IPPI'
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MISS/archival_pdf/MISS.ISS.IPPI.archival.pdf"  # a PDF with 3 pages
-      object.datastreams["Archival.pdf"].mimeType = "application/pdf"
-      object.save!
-
-      job = Job::CreateDerivatives.new('uuid', 'record_id' => object.id)
-
-      pdf_path = object.local_path_for('Archival.pdf')
-      hidden_pdf_path = pdf_path + '.hide'
-      FileUtils.mv(pdf_path, hidden_pdf_path)
+      job = Job::CreateDerivatives.new('uuid', 'record_id' => subject.id)
+      subject.datastreams['Archival.pdf'].dsLocation = 'http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MISS/archival_pdf/non-existant.pdf'
+      subject.save
       expect{job.perform}.to raise_error(Magick::ImageMagickError)
-      FileUtils.mv(hidden_pdf_path, pdf_path)
     end
 
     it 'raises an error if it doesn''t have write permission to the derivatives folder' do
-      object = TuftsPdf.new(title: 'test create derivative', displays: ['dl'])
-      object.inner_object.pid = 'tufts:MISS.ISS.IPPI'
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MISS/archival_pdf/MISS.ISS.IPPI.archival.pdf"  # a PDF with 3 pages
-      object.datastreams["Archival.pdf"].mimeType = "application/pdf"
-      object.save!
-
-      job = Job::CreateDerivatives.new('uuid', 'record_id' => object.id)
-
-			derivatives_path = object.local_path_for_pdf_derivatives()
+      job = Job::CreateDerivatives.new('uuid', 'record_id' => subject.id)
+			derivatives_path = subject.local_path_for_pdf_derivatives
       FileUtils.mkdir_p(derivatives_path)  # in case the derivatives folder doesn't already exist
       FileUtils.chmod(0444, derivatives_path)
+
       expect{job.perform}.to raise_error(Errno::EACCES)
+
       FileUtils.chmod(0755, derivatives_path)
     end
 
     it 'creates derivatives' do
-      object = TuftsPdf.new(title: 'test create derivative', displays: ['dl'])
-      object.inner_object.pid = 'tufts:MISS.ISS.IPPI'
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MISS/archival_pdf/MISS.ISS.IPPI.archival.pdf"  # a PDF with 3 pages
-      object.datastreams["Archival.pdf"].mimeType = "application/pdf"
-      object.save!
 
-      job = Job::CreateDerivatives.new('uuid', 'record_id' => object.id)
+      job = Job::CreateDerivatives.new('uuid', 'record_id' => subject.id)
 
       # remove previously generated derivatives, if any
-      FileUtils.remove_dir(object.local_path_for_pdf_derivatives(), true)
+      FileUtils.remove_dir(subject.local_path_for_pdf_derivatives(), true)
 
       job.perform
 
-      expect(File.exists?(object.local_path_for_book_meta())).to be_truthy
-      expect(File.exists?(object.local_path_for_readme())).to be_truthy
-      expect(File.exists?(object.local_path_for_png(0))).to be_truthy
+      expect(File.exists?(subject.local_path_for_book_meta)).to be_truthy
+      expect(File.exists?(subject.local_path_for_readme)).to be_truthy
+      expect(File.exists?(subject.local_path_for_png(0))).to be_truthy
     end
 
     it 'puts derivatives in the right places' do
-      object = TuftsPdf.new(title: 'test create derivative', displays: ['dl'])
-      object.inner_object.pid = 'tufts:MISS.ISS.IPPI'
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MISS/archival_pdf/MISS.ISS.IPPI.archival.pdf"  # a PDF with 3 pages
-      object.datastreams["Archival.pdf"].mimeType = "application/pdf"
-      object.save!
 
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MS083/archival_pdf/MS083.001.001.00013.archival.pdf"
-      expect(object.local_path_for_pdf_derivatives()).to end_with "/dcadata02/tufts/central/dca/MS083/access_pdf_pageimages/MS083.001.001.00013"
+      subject.datastreams['Archival.pdf'].dsLocation = 'http://bucket01.lib.tufts.edu/data01/tufts/central/dca/MS083/archival_pdf/MS083.001.001.00013.archival.pdf'
+      expect(subject.local_path_for_pdf_derivatives).to end_with '/dcadata02/tufts/central/dca/MS083/access_pdf_pageimages/MS083.001.001.00013'
 
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data01/tufts/facpubs/mpokras-2007/archival_pdf/nriagu-1983.00001.archival.pdf"
-      expect(object.local_path_for_pdf_derivatives()).to end_with "/dcadata02/tufts/facpubs/mpokras-2007/access_pdf_pageimages/facpubs.nriagu-1983.00001"
+      subject.datastreams['Archival.pdf'].dsLocation = 'http://bucket01.lib.tufts.edu/data01/tufts/facpubs/mpokras-2007/archival_pdf/nriagu-1983.00001.archival.pdf'
+      expect(subject.local_path_for_pdf_derivatives).to end_with '/dcadata02/tufts/facpubs/mpokras-2007/access_pdf_pageimages/facpubs.nriagu-1983.00001'
 
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/data05/tufts/central/dca/MS001/archival_pdf/MS001.008.001.00002.archival.pdf"
-      expect(object.local_path_for_pdf_derivatives()).to end_with "/dcadata02/tufts/central/dca/MS001/access_pdf_pageimages/MS001.008.001.00002"
+      subject.datastreams['Archival.pdf'].dsLocation = 'http://bucket01.lib.tufts.edu/data05/tufts/central/dca/MS001/archival_pdf/MS001.008.001.00002.archival.pdf'
+      expect(subject.local_path_for_pdf_derivatives).to end_with '/dcadata02/tufts/central/dca/MS001/access_pdf_pageimages/MS001.008.001.00002'
 
-      object.datastreams["Archival.pdf"].dsLocation = "http://bucket01.lib.tufts.edu/ase_data/tisch01/archival_pdf/12385.archival.pdf"
-      expect(object.local_path_for_pdf_derivatives()).to end_with "/ase_data/tisch01/access_pdf_pageimages/12385"
+      subject.datastreams['Archival.pdf'].dsLocation = 'http://bucket01.lib.tufts.edu/ase_data/tisch01/archival_pdf/12385.archival.pdf'
+      expect(subject.local_path_for_pdf_derivatives).to end_with '/ase_data/tisch01/access_pdf_pageimages/12385'
     end
   end
 


### PR DESCRIPTION
@bgoodmon reconfigured the test env to not send emails, like i said in the comment maybe you could add a spec for this but it'd be weird to send a notification out every time the test is run.  tried to reorg the spec a bit using before blocks.  Note the gemfile here points to a version of tufts_models which doesn't yet have the corresponding pdf derivative code yet so may want to deal with merging tufts_models first then do this one.
